### PR TITLE
Support JUnit XML as an output format for integration of results with other CI services

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,26 @@ HIPAA scans map CloudSploit plugins to the Health Insurance Portability and Acco
 
 PCI scans map CloudSploit plugins to the Payment Card Industry Data Security Standard.
 
+## Output Formats
+
+CloudSploit supports output in several formats for consumption by other tools.
+If you do not specify otherwise, CloudSploit writes output to standard output
+(the console). You can specify one or more output formats as follows:
+
+```
+# Output results in CSV (suppressing the console output)
+node index.js --csv=./out.csv
+
+# Output results in JUnit XML (suppressing the console output)
+node index.js --junit=./out.xml
+
+# Output results only to the console (default if omitted)
+node index.js --console
+
+# Output results in all supported formats
+node index.js --console --junit=./out.xml --csv=./out.csv
+```
+
 ## Architecture
 
 CloudSploit works in two phases. First, it queries the AWS APIs for various metadata about your account. This is known as the "collection" phase. Once all the necessary data has been collected, the result is passed to the second phase - "scanning." The scan uses the collected data to search for potential misconfigurations, risks, and other security issues. These are then provided as output.

--- a/index.js
+++ b/index.js
@@ -182,11 +182,13 @@ for (p in plugins) {
 			var plugin = getMapValue(serviceProviderPlugins, spp);
 			// Skip GitHub plugins that do not match the run type
 			if (sp == 'github' && serviceProviderConfig.org && !plugin.org) continue;
-			if (compliance.includes(spp, plugin)) {
-				for (pac in plugin.apis) {
-					if (serviceProviderAPICalls.indexOf(plugin.apis[pac]) === -1) {
-						serviceProviderAPICalls.push(plugin.apis[pac]);
-					}
+			
+			// Skip if our compliance set says don't run the rule
+			if (!compliance.includes(spp, plugin)) continue;
+
+			for (pac in plugin.apis) {
+				if (serviceProviderAPICalls.indexOf(plugin.apis[pac]) === -1) {
+					serviceProviderAPICalls.push(plugin.apis[pac]);
 				}
 			}
 		}
@@ -252,6 +254,7 @@ async.map(serviceProviders, function (serviceProviderObj, serviceProviderDone) {
 	});
 }, function (err, results) {
 	// console.log(JSON.stringify(collection, null, 2));
+	outputHandler.close()
 	if (useStatusExitCode) {
 		process.exitCode = Math.max(results)
 	}

--- a/postprocess/output.js
+++ b/postprocess/output.js
@@ -5,7 +5,7 @@ var fs = require('fs');
 // directly to the console.
 var consoleOutputHandler = {
     startCompliance: function(plugin, pluginKey, compliance) {
-        var complianceDesc = compliance.describe(pluginKey, plugin)
+        var complianceDesc = compliance.describe(pluginKey, plugin);
         if (complianceDesc) {
             console.log('');
             console.log('-----------------------');
@@ -36,53 +36,230 @@ var consoleOutputHandler = {
 						(result.resource || 'N/A') + '\t' +
 						(result.region || 'Global') + '\t\t' +
 						statusWord + '\t' + result.message);
-    }
-}
-
-// Defines a way to write to CSV output. To use this, set the writer
-// property and then you can write results to CSV.
-var csvOutputHandler = {
-    writer: undefined,
-
-    startCompliance: function(plugin, pluginKey, compliance) {
     },
 
-    endCompliance: function(plugin, pluginKey, compliance) {
-    },
-
-    writeResult: function (result, plugin, pluginKey) {
-        var statusWord;
-        if (result.status === 0) {
-            statusWord = 'OK';
-        } else if (result.status === 1) {
-            statusWord = 'WARN';
-        } else if (result.status === 2) {
-            statusWord = 'FAIL';
-        } else {
-            statusWord = 'UNKNOWN';
-        }
-
-        this.writer.write([plugin.category, plugin.title, (result.resource || 'N/A'), (result.region || 'Global'), statusWord, result.message])
-    },
-
-    close: function () {
-        this.writer.end()
-    }
+    close: function() {}
 }
 
 module.exports = {
+    /**
+     * Creates an output handler that writes output in the CSV format.
+     * @param {fs.WriteSteam} stream The stream to write to or an object that
+     * obeys the writeable stream contract.
+     */
+    createCsv: function (stream) {
+        var writer = csvWriter({headers: ['category', 'title', 'resource',
+                                          'region', 'statusWord', 'message']});
+        writer.pipe(stream);
+
+        return {
+            writer: writer,
+        
+            startCompliance: function(plugin, pluginKey, compliance) {
+            },
+        
+            endCompliance: function(plugin, pluginKey, compliance) {
+            },
+        
+            writeResult: function (result, plugin, pluginKey) {
+                var statusWord;
+                if (result.status === 0) {
+                    statusWord = 'OK';
+                } else if (result.status === 1) {
+                    statusWord = 'WARN';
+                } else if (result.status === 2) {
+                    statusWord = 'FAIL';
+                } else {
+                    statusWord = 'UNKNOWN';
+                }
+        
+                this.writer.write([plugin.category, plugin.title,
+                                   (result.resource || 'N/A'),
+                                   (result.region || 'Global'),
+                                   statusWord, result.message]);
+            },
+        
+            close: function () {
+                this.writer.end();
+            }
+        }
+    },
+
+    /***
+     * Creates an output handler that writes output in the JUnit XML format.
+     * 
+     * This constructs the XML directly, rather than through a library so that
+     * we don't need to pull in another NPM dependency. This keeps things
+     * simple.
+     * 
+     * @param {fs.WriteStream} stream The stream to write to or an object that
+     * obeys the writeable stream contract.
+     */
+    createJunit: function (stream) {
+        return {
+            stream: stream,
+        
+            /**
+             * The test suites are how we represent result - each test suite
+             * maps to one plugin (more specifically the plugin key) so that
+             * we group tests based on the plugin key.
+             */
+            testSuites: {},
+
+            startCompliance: function(plugin, pluginKey, compliance) {
+            },
+        
+            endCompliance: function(plugin, pluginKey, compliance) {
+            },
+        
+            /**
+             * Adds the result to be written to the output file.
+             */
+            writeResult: function (result, plugin, pluginKey) {
+                var suiteName = pluginKey;
+                if (!this.testSuites.hasOwnProperty(suiteName)) {
+                    // The time to report for the tests (since we don't have
+                    // time for any of them.) The expected JUnit format doesn't
+                    // allow for time or MS, so omit those
+                    var time = (new Date()).toISOString();
+                    time = time.substr(0, time.indexOf('.'));
+
+                    this.testSuites[suiteName] = {
+                        name: plugin.title + ': ' + (plugin.description || ''),
+                        package: pluginKey,
+                        failures: 0,
+                        errors: 0,
+                        testCases: [],
+                        time: time
+                    };
+                }
+
+                // Get the test suite that we want to add to
+                var testSuite = this.testSuites[pluginKey];
+
+                // Was this test an error or failure?
+                var failure = result.status === 2 ? (result.message || 'Unexpected failure') : undefined;
+                testSuite.failures += failure ? 1 : 0;
+                var error = result.status > 2 ? (result.message || 'Unexpected error') : undefined;
+                testSuite.errors += error ? 1 : 0;
+
+                // Each plugin can generate multiple results, which we map as
+                // one plugin to one test suite. Each result in that suite needs
+                // to have enough context to be useful (even for passes), so
+                // we add all of that that information at the name of the test
+                var name = result.region + '; ' + (result.resource || 'N/A') + '; ' + result.message;
+
+                testSuite.testCases.push({
+                    name: name,
+                    classname: pluginKey,
+                    file: '',
+                    line: 0,
+                    failure: failure,
+                    error: error
+                });
+            },
+        
+            /**
+             * Closes the output handler. For this JUnit output handler, all of
+             * the work happens on close since we need to know information
+             * about results upfront.
+             */
+            close: function () {
+                this.stream.write('<?xml version="1.0" encoding="UTF-8" ?>\n');
+                this.stream.write('<testsuites>\n');
+
+                var index = 0;
+                for (var key in this.testSuites) {
+                    this._writeSuite(this.testSuites[key], index);
+                    index += 1;
+                }
+
+                this.stream.write('</testsuites>\n');
+                
+                this.stream.end();
+            },
+
+            /**
+             * Writes the test suite to the output stream. This should really
+             * only be called internally by this class.
+             * @param testSuite The test suite to write to the stream
+             */
+            _writeSuite: function (testSuite, index)  {
+                var numTests = testSuite.testCases.length;
+
+                this.stream.write('\t<testsuite name="' + testSuite.name +
+                                  '" hostname="localhost" tests="' + numTests +
+                                  '" errors="' + testSuite.errors +
+                                  '" failures="' + testSuite.failures +
+                                  '" timestamp="' + testSuite.time +
+                                  '" time="0" package="' + testSuite.package +
+                                  '" id="' + index + '">\n');
+
+                // The schema says we must have the properties element, but it can be empty
+                this.stream.write('\t\t<properties></properties>\n');
+                for (var testCase of testSuite.testCases) {
+                    this.stream.write('\t\t<testcase classname="' +
+                                      testCase.classname +'" name="' +
+                                      testCase.name + '" time="0"');
+
+                    // If we need a child, then write that, otherwise close
+                    // of the test case without creating an unnecessary text
+                    // element
+                    if (testCase.failure) {
+                        this.stream.write('>\n\t\t\t<failure message="' +
+                                          testCase.failure + '" type="none"/>\n' +
+                                          '\t\t</testcase>\n');
+                    } else if (testCase.error) {
+                        this.stream.write('>\n\t\t\t<failure message="' +
+                                          testCase.error + '" type="none"/>\n' +
+                                          '\t\t</testcase>\n');
+                    } else {
+                        this.stream.write('/>\n');
+                    }
+                    
+                }
+
+                // Same thing with properties above - this just needs to exist
+                // even if we don't have data (according to the schema)
+                this.stream.write('\t\t<system-out></system-out>\n');
+                this.stream.write('\t\t<system-err></system-err>\n');
+
+                this.stream.write('\t</testsuite>\n');
+            }
+        }
+    },
+
+    /**
+     * Creates an output handler depending on the arguments list as expected
+     * in the command line format. If multiple output handlers are specified
+     * in the arguments, then constructs a unified view so that it appears that
+     * there is only one output handler.
+     * 
+     * @param {string[]} argv Array of command line arguments (may contain
+     * arguments that are not relevant to constructing output handlers).
+     * 
+     * @return A object that obeys the output handler contract. This may be
+     * one output handler or one that forwards function calls to a group of
+     * output handlers.
+     */
     create: function (argv) {
         var outputs = [];
 
         // Creates the handlers for writing output.
         var addCsvOutput = argv.find(function (arg) {
-            return arg.startsWith('--csv=')
+            return arg.startsWith('--csv=');
         })
         if (addCsvOutput) {
-            var writer = csvWriter({headers: ['category', 'title', 'resource', 'region', 'statusWord', 'message']});
-            writer.pipe(fs.createWriteStream(addCsvOutput.substr(6)));
-            csvOutputHandler.writer = writer
-            outputs.push(csvOutputHandler);
+            var stream = fs.createWriteStream(addCsvOutput.substr(6));
+            outputs.push(this.createCsv(stream));
+        }
+
+        var addJunitOutput = argv.find(function (arg) {
+            return arg.startsWith('--junit=');
+        })
+        if (addJunitOutput) {
+            var stream = fs.createWriteStream(addJunitOutput.substr(8));
+            outputs.push(this.createJunit(stream));
         }
 
         var addConsoleOutput = argv.find(function (arg) {

--- a/postprocess/output.spec.js
+++ b/postprocess/output.spec.js
@@ -1,0 +1,126 @@
+var assert = require('assert');
+var expect = require('chai').expect;
+var output = require('./output')
+
+/**
+ * Creates an object that looks like an output stream that we can write
+ * to (but is actually just a buffer caching the data)
+ */
+var createOutputBuffer = function () {
+    return {
+        cache: '',
+
+        write: function (data) {
+            this.cache += data;
+        },
+
+        end: function () {},
+        on: function (event, fn) {},
+        once: function(event, fn) {},
+        emit: function(even, fn) {}
+    }
+}
+
+describe('output', function () {
+    describe('junit', function () {
+        it('should generate empty junit when no results', function () {
+            var buffer = createOutputBuffer();
+            var handler = output.createJunit(buffer);
+            handler.close();
+            expect(buffer.cache).to.equal(
+                '<?xml version="1.0" encoding="UTF-8" ?>\n' + 
+                '<testsuites>\n</testsuites>\n');
+        })
+
+        it('should indicate one pass there is one passing result', function () {
+            var buffer = createOutputBuffer();
+            var handler = output.createJunit(buffer);
+            handler.writeResult({status: 0}, {title:'myTitle'}, 'key');
+            handler.close();
+
+            expect(buffer.cache).to.include(' tests="1" ');
+            expect(buffer.cache).to.include(' failures="0" ');
+            expect(buffer.cache).to.include(' errors="0" ');
+        })
+
+        it('should indicate one failure there is one failing result', function () {
+            var buffer = createOutputBuffer();
+            var handler = output.createJunit(buffer);
+            handler.writeResult({status: 2, message: 'fail message'}, {title:'myTitle'}, 'key');
+            handler.close();
+
+            expect(buffer.cache).to.include(' tests="1" ');
+            expect(buffer.cache).to.include(' failures="1" ');
+            expect(buffer.cache).to.include(' errors="0" ');
+            expect(buffer.cache).to.include('fail message');
+        })
+
+        it('should indicate one error there is one failing error', function () {
+            var buffer = createOutputBuffer();
+            var handler = output.createJunit(buffer);
+            handler.writeResult({status: 3, message: 'error message'}, {title:'myTitle'}, 'key');
+            handler.close();
+
+            expect(buffer.cache).to.include(' tests="1" ');
+            expect(buffer.cache).to.include(' failures="0" ');
+            expect(buffer.cache).to.include(' errors="1" ');
+            expect(buffer.cache).to.include('error message');
+        })
+    })
+
+    describe('csv', function () {
+        it('should generate only header if no results', function () {
+            var buffer = createOutputBuffer();
+            var handler = output.createCsv(buffer);
+            handler.close();
+            expect(buffer.cache).to.equal('');
+        })
+
+        it('should indicate one pass there is one passing result', function () {
+            var buffer = createOutputBuffer();
+            var handler = output.createCsv(buffer);
+            handler.writeResult({status: 0}, {title:'myTitle'}, 'key');
+            handler.close();
+
+            expect(buffer.cache).to.equal('category,title,resource,region,statusWord,message\n,myTitle,N/A,Global,OK,\n');
+        })
+    })
+
+    describe('create', function() {
+        it('should write to console without errors', function () {
+            // Create with no arguments is valid and just says create the
+            // default, which is console output.
+            var handler = output.create([])
+
+            handler.writeResult({status: 0}, {title:'myTitle'}, 'key');
+            handler.close();
+            // No expect here because in the current structure, we cannot
+            // capture the standard output
+        })
+
+        it('should handle compliance sections without errors', function () {
+            // Create with no arguments is valid and just says create the
+            // default, which is console output.
+            var handler = output.create([]);
+
+            // Create the information about the compliance rule - for this
+            // test, it doesn't have to be anything fancy
+            var complianceRule = {
+                describe: function (pluginKey, plugin) {
+                    return 'desc';
+                }
+            };
+            var plugin = {
+                title: 'title'
+            };
+            var pluginKey = 'someIdentifier';
+
+            handler.startCompliance(plugin, pluginKey, complianceRule);
+            handler.writeResult({status: 0}, {title:'myTitle'}, 'key');
+            handler.endCompliance(plugin, pluginKey, complianceRule);
+            handler.close();
+            // No expect here because in the current structure, we cannot
+            // capture the standard output
+        })
+    })
+})


### PR DESCRIPTION
This pull request adds support JUnit XML as an output format. This enables integration with services that can consume JUnit XML as an output, such as a CI service.

Adds new tests in order to prove this works. Adds information to the README to explain how to generate JUNIT output.

This commit was rebased in order to have a clean history and resolve merge conflicts out of band.